### PR TITLE
fix: Normalize API base URL to prevent double slashes in multiple com…

### DIFF
--- a/PrajaShakthi-VDP-Form-frontend/src/components/ActivityLogs.jsx
+++ b/PrajaShakthi-VDP-Form-frontend/src/components/ActivityLogs.jsx
@@ -4,7 +4,8 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import axios from 'axios';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+// Normalize API base URL to avoid double slashes when joining paths
+const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:5000').replace(/\/+$/, '');
 
 const ActivityLogs = () => {
     const { user } = useAuth();

--- a/PrajaShakthi-VDP-Form-frontend/src/components/NotificationBell.jsx
+++ b/PrajaShakthi-VDP-Form-frontend/src/components/NotificationBell.jsx
@@ -4,7 +4,8 @@ import React, { useState, useEffect } from 'react';
 import { useAuth } from '../context/AuthContext';
 import axios from 'axios';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+// Normalize API base URL to avoid double slashes when joining paths
+const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:5000').replace(/\/+$/, '');
 
 const NotificationBell = ({ setCurrentRoute }) => {
     const { isSuperAdmin, isDistrictAdmin } = useAuth();

--- a/PrajaShakthi-VDP-Form-frontend/src/components/NotificationsPage.jsx
+++ b/PrajaShakthi-VDP-Form-frontend/src/components/NotificationsPage.jsx
@@ -4,7 +4,8 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../context/AuthContext';
 import axios from 'axios';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+// Normalize API base URL to avoid double slashes when joining paths
+const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:5000').replace(/\/+$/, '');
 
 const NotificationsPage = () => {
     const { isSuperAdmin, isDistrictAdmin } = useAuth();

--- a/PrajaShakthi-VDP-Form-frontend/src/components/UserManagement.jsx
+++ b/PrajaShakthi-VDP-Form-frontend/src/components/UserManagement.jsx
@@ -5,7 +5,8 @@ import { useAuth } from '../context/AuthContext';
 import axios from 'axios';
 import provincialData from '../data/provincial_data.json';
 
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+// Normalize API base URL to avoid double slashes when joining paths
+const API_URL = (import.meta.env.VITE_API_URL || 'http://localhost:5000').replace(/\/+$/, '');
 
 const UserManagement = () => {
     const { user } = useAuth();


### PR DESCRIPTION
This pull request standardizes how the API base URL is defined across multiple frontend components to prevent issues with double slashes when joining URL paths. The change ensures that any trailing slashes are removed from the API URL, improving reliability when making requests.

**API URL normalization:**

* Updated the definition of `API_URL` in the following components to strip trailing slashes, preventing double slashes in API requests:
  - `ActivityLogs.jsx`
  - `NotificationBell.jsx`
  - `NotificationsPage.jsx`
  - `UserManagement.jsx`