### PR TITLE
Limit edit submission access to DS users only

### DIFF
--- a/PrajaShakthi-VDP-Form-backend/controllers/submissionController.js
+++ b/PrajaShakthi-VDP-Form-backend/controllers/submissionController.js
@@ -294,7 +294,7 @@ const deleteSubmission = async (req, res) => {
 
 // @desc   Update a submission
 // @route  PUT /api/submissions/:id
-// @access Private (DS Users can edit their own)
+// @access Private (Only DS Users can edit their own submissions)
 const updateSubmission = async (req, res) => {
   try {
     const user = req.user;
@@ -304,13 +304,12 @@ const updateSubmission = async (req, res) => {
       return res.status(404).json({ message: "Submission not found" });
     }
 
-    // Permission check: DS users can only edit their own submissions
-    if (user.role === 'ds_user' && submission.createdBy.toString() !== user._id.toString()) {
-      return res.status(403).json({ message: "Not authorized to edit this submission" });
+    // Permission check: ONLY DS users can edit, and only their own submissions
+    if (user.role !== 'ds_user') {
+      return res.status(403).json({ message: "Only DS users can edit submissions" });
     }
 
-    // District admins can edit submissions from their district
-    if (user.role === 'district_admin' && submission.location.district !== user.district) {
+    if (submission.createdBy.toString() !== user._id.toString()) {
       return res.status(403).json({ message: "Not authorized to edit this submission" });
     }
 

--- a/PrajaShakthi-VDP-Form-frontend/src/components/SubmissionList.jsx
+++ b/PrajaShakthi-VDP-Form-frontend/src/components/SubmissionList.jsx
@@ -1580,12 +1580,15 @@ const SubmissionList = () => {
                   History ({submission.editHistory.length})
                 </button>
               )}
-              <button
-                onClick={() => handleEdit(submission)}
-                className="bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md px-3 py-1 text-sm transition duration-150 ease-in-out"
-              >
-                Edit
-              </button>
+              {/* Only DS users can edit their own submissions */}
+              {isDSUser && submission.createdBy === user._id && (
+                <button
+                  onClick={() => handleEdit(submission)}
+                  className="bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md px-3 py-1 text-sm transition duration-150 ease-in-out"
+                >
+                  Edit
+                </button>
+              )}
               <button
                 onClick={() => handleDelete(submission._id)}
                 className="bg-red-600 hover:bg-red-700 text-white font-medium rounded-md px-3 py-1 text-sm transition duration-150 ease-in-out"


### PR DESCRIPTION
- Frontend: Hide Edit button for SuperAdmin and District Admin
- Frontend: DS users only see Edit button for their own submissions
- Backend: Restrict PUT /api/submissions/:id to DS users only
- Backend: Enforce ownership check - DS users can only edit their own submissions