### PR TITLE
Development

### DIFF
--- a/PrajaShakthi-VDP-Form-backend/controllers/submissionController.js
+++ b/PrajaShakthi-VDP-Form-backend/controllers/submissionController.js
@@ -294,7 +294,7 @@ const deleteSubmission = async (req, res) => {
 
 // @desc   Update a submission
 // @route  PUT /api/submissions/:id
-// @access Private (DS Users can edit their own)
+// @access Private (Only DS Users can edit their own submissions)
 const updateSubmission = async (req, res) => {
   try {
     const user = req.user;
@@ -304,13 +304,12 @@ const updateSubmission = async (req, res) => {
       return res.status(404).json({ message: "Submission not found" });
     }
 
-    // Permission check: DS users can only edit their own submissions
-    if (user.role === 'ds_user' && submission.createdBy.toString() !== user._id.toString()) {
-      return res.status(403).json({ message: "Not authorized to edit this submission" });
+    // Permission check: ONLY DS users can edit, and only their own submissions
+    if (user.role !== 'ds_user') {
+      return res.status(403).json({ message: "Only DS users can edit submissions" });
     }
 
-    // District admins can edit submissions from their district
-    if (user.role === 'district_admin' && submission.location.district !== user.district) {
+    if (submission.createdBy.toString() !== user._id.toString()) {
       return res.status(403).json({ message: "Not authorized to edit this submission" });
     }
 

--- a/PrajaShakthi-VDP-Form-frontend/src/components/SubmissionList.jsx
+++ b/PrajaShakthi-VDP-Form-frontend/src/components/SubmissionList.jsx
@@ -1580,12 +1580,15 @@ const SubmissionList = () => {
                   History ({submission.editHistory.length})
                 </button>
               )}
-              <button
-                onClick={() => handleEdit(submission)}
-                className="bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md px-3 py-1 text-sm transition duration-150 ease-in-out"
-              >
-                Edit
-              </button>
+              {/* Only DS users can edit their own submissions */}
+              {isDSUser && submission.createdBy === user._id && (
+                <button
+                  onClick={() => handleEdit(submission)}
+                  className="bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md px-3 py-1 text-sm transition duration-150 ease-in-out"
+                >
+                  Edit
+                </button>
+              )}
               <button
                 onClick={() => handleDelete(submission._id)}
                 className="bg-red-600 hover:bg-red-700 text-white font-medium rounded-md px-3 py-1 text-sm transition duration-150 ease-in-out"


### PR DESCRIPTION
This pull request strengthens submission editing permissions for DS users, ensuring that only DS users can edit submissions they created. It updates both backend permission checks and the frontend UI to reflect this stricter access control.

**Backend permission enforcement:**

* Updated the `updateSubmission` controller in `submissionController.js` to restrict editing permissions so that only DS users can edit submissions, and only those submissions they created. District admins can no longer edit submissions from their district. [[1]](diffhunk://#diff-c42009d44c9d909a485b8588f0d77508122b2a95fc5336846aee9d17ab3a5701L297-R297) [[2]](diffhunk://#diff-c42009d44c9d909a485b8588f0d77508122b2a95fc5336846aee9d17ab3a5701L307-R312)

**Frontend UI updates:**

* Modified the `SubmissionList` component in `SubmissionList.jsx` to display the "Edit" button only for DS users and only for submissions they created, ensuring the UI matches the new backend restrictions.