### PR TITLE
Enhance edit button logic for DS users by refining user ID comparison

### DIFF
--- a/PrajaShakthi-VDP-Form-frontend/src/components/SubmissionList.jsx
+++ b/PrajaShakthi-VDP-Form-frontend/src/components/SubmissionList.jsx
@@ -1562,8 +1562,9 @@ const SubmissionList = () => {
               {console.log('🔍 Edit Button Check:', {
                 isDSUser,
                 submissionCreatedBy: submission.createdBy,
+                submissionCreatedById: submission.createdBy?._id,
                 userId: user?._id,
-                match: String(submission.createdBy) === String(user?._id)
+                match: String(submission.createdBy?._id || submission.createdBy) === String(user?._id)
               })}
               
               {activeTab === "council_info" && (
@@ -1589,8 +1590,8 @@ const SubmissionList = () => {
                 </button>
               )}
               {/* Only DS users can edit their own submissions */}
-              {isDSUser && submission.createdBy && user?._id && 
-               String(submission.createdBy) === String(user._id) && (
+              {isDSUser && (submission.createdBy?._id || submission.createdBy) && user?._id && 
+               String(submission.createdBy?._id || submission.createdBy) === String(user._id) && (
                 <button
                   onClick={() => handleEdit(submission)}
                   className="bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md px-3 py-1 text-sm transition duration-150 ease-in-out"


### PR DESCRIPTION
This pull request updates the logic for checking if a DS user can edit their own submission in the `SubmissionList` component. The main improvement is handling cases where `createdBy` may be either an object (with an `_id` property) or a primitive value, ensuring the comparison works correctly regardless of the data structure.

**Improvements to edit permission logic:**

* Updated the edit button check and conditional rendering to support both object and primitive forms of `submission.createdBy`, preventing permission errors when the data structure varies. [[1]](diffhunk://#diff-e1d94e1ff9c0af97df6ea1c84b0ffbd819f2e75ce8c5c9262fa655e4f475d94cR1565-R1567) [[2]](diffhunk://#diff-e1d94e1ff9c0af97df6ea1c84b0ffbd819f2e75ce8c5c9262fa655e4f475d94cL1592-R1594)